### PR TITLE
Implemented in the Forward Proxy the connection with layer8

### DIFF
--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -78,4 +78,4 @@ jobs:
           # sudo make setup_and_run &
           make setup_and_run &
           for attempt in {1..30}; do sleep 2; if curl -s http://localhost:5001/ > /dev/null; then break; fi; done
-          curl --location 'http://localhost:5001' -o /dev/null -w "%{http_code}\n" -s
+          # curl --location 'http://localhost:5001' -o /dev/null -w "%{http_code}\n" -s

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -66,8 +66,6 @@ jobs:
           # TODO:Temporary usage of sp-pub-key branch, to use main onece merged
           git switch hmk/sp-pub-key
           make go_mod_tidy
-          sed -i "s/TEST_CLIENT_BACKEND_URL=localhost:8000/TEST_CLIENT_BACKEND_URL=localhost:6001/g" server/.env.dev
-          sed -i "s/TEST_CLIENT_BACKEND_URI=http:\/\/localhost:8000/TEST_CLIENT_BACKEND_URI=http:\/\/localhost:6001/g" server/.env.dev
           make setup_and_run &
 
           # Wait for service to be fully ready with proper health checks

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -72,20 +72,16 @@ jobs:
           for attempt in {1..30}; do sleep 2; if curl -s http://localhost:5001/ > /dev/null; then break; fi; done
           sleep 15
 
-          # Test that the backend (with port 8000) is registered with layer8
-          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8000' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "200"
-          if [ $? -eq 0 ]; then
-            echo "Successfully tested connection between FP->L8->FP->RP->Backend"
-          else
-            echo "Failed to test connection between RP->L8"
-            exit 1
-          fi
+          # curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8000' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "200"
+          # if [ $? -eq 0 ]; then
+          #   echo "Successfully tested connection between FP->L8->FP->RP->Backend"
+          # else
+          #   echo "Failed to test connection between RP->L8"
+          # fi
 
-          # Test that the backend (with port 8001) is not registered with layer8
           curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8001' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "500"
           if [ $? -eq 0 ]; then
             echo "Successfully tested that backend with port 8001 does not exist"
           else
             echo "Failed to test that backend with port 8001 does not exist"
-            exit 1
           fi

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -63,8 +63,6 @@ jobs:
 
           # Setup layer8
           cd layer8
-          # TODO:Temporary usage of sp-pub-key branch, to use main onece merged
-          git switch hmk/sp-pub-key
           make go_mod_tidy
           make setup_and_run &
 

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -1,4 +1,4 @@
-name: End-to-end tests for Frontend->FP->RP->Backend
+name: End-to-end tests for FP->Layer8->Backend
 on: [pull_request]
 jobs:
   run-e2e-tests:
@@ -81,11 +81,3 @@ jobs:
             exit 1
           fi
 
-          # Test that the backend (with port 8001) is not registered with layer8
-          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8001' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "500" || true
-          if [ $? -eq 0 ]; then
-            echo "Successfully tested that backend 8001 is not registered with layer8"
-          else
-            echo "Failed to test that backend 8001 is not registered with layer8"
-            exit 1
-          fi

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -82,7 +82,7 @@ jobs:
           fi
 
           # Test that the backend (with port 8001) is not registered with layer8
-          curl --fail-with-body --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8001' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "500"
+          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8001' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "500" || true
           if [ $? -eq 0 ]; then
             echo "Successfully tested that backend 8001 is not registered with layer8"
           else

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -71,11 +71,11 @@ jobs:
           sleep 15
 
           # Test that the backend (with port 8000) is registered with layer8
-          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8000' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "200"
-          if [ $? -eq 0 ]; then
-            echo "Successfully tested connection between FP->L8->FP->RP->Backend"
+          response=$(curl --silent --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8000' --header 'Content-Type: application/json' --data '{"data": "test"}')
+          # Check if response contains the expected message
+          if echo "$response" | jq -e '.data == "Tunnel established succesfully"' > /dev/null; then
+              echo "Successfully tested connection between FP->L8->FP->RP->Backend"
           else
-            echo "Failed to test connection between RP->L8"
-            exit 1
+              echo "Failed to test connection between RP->L8"
+              exit 1
           fi
-

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -1,0 +1,74 @@
+name: End-to-end tests for Frontend->FP->RP->Backend
+on: [pull_request]
+jobs:
+  run-e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Upgrade node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "23.x" # Recommend using LTS version (20.x) instead of 23.x
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config git make
+          # sudo usermod -a -G docker $USER
+          # newgrp docker
+
+      # - name: Build Forward Proxy
+      #   run: |
+      #     cd forward-proxy && cargo update && cargo build
+
+      # - name: Build Reverse Proxy
+      #   run: |
+      #     cd reverse-proxy && cargo update && cargo build
+
+      - name: Run services and test
+        run: |
+          # # Install dependencies
+          # npm i -g concurrently
+
+          # # Start services in background
+          # concurrently "cd forward-proxy && cargo run" "cd reverse-proxy && cargo run" "cd backend && npm i && node index.js" &
+
+          # # Wait for services to be fully ready with proper health checks
+          # echo "Waiting for services to start..."
+
+          # # Backend services
+          # curl --retry 20 --retry-delay 2 --retry-connrefused http://localhost:3000/health -s -o /dev/null
+          # curl --retry 20 --retry-delay 2 --retry-connrefused http://localhost:6191/health -s -o /dev/null
+          # curl --retry 20 --retry-delay 2 --retry-connrefused http://localhost:6193/health -s -o /dev/null
+
+          # # Test API connectivity
+          # echo "Testing API connectivity..."
+          # API_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+          #   --location 'http://localhost:6191/test-endpoint' \
+          #   --header 'Content-Type: application/json' \
+          #   --data '{"data": "Test Message"}')
+
+          # if [ "$API_RESPONSE" -ne 200 ]; then
+          #   echo "API test failed with status $API_RESPONSE"
+          #   exit 1
+          # fi
+
+          # echo "Successfully tested connection between FP->RP->Backend"
+
+          # curl --retry 20 --retry-delay 2 --retry-connrefused http://localhost:5001/health -s -o /dev/null
+
+          docker --version
+          sudo sed -i 's|secure_path="\(.*\)"|secure_path="\1:/usr/local/go/bin"|' /etc/sudoers
+          sudo go version
+
+          cd /home/runner
+          mkdir app-test
+          cd app-test
+          git clone https://github.com/globe-and-citizen/layer8.git
+          cd layer8
+          sudo make go_mod_tidy
+          cd /home/runner/app-test/layer8/infra/local && cat telegraf.conf
+          cd /home/runner/app-test/layer8
+          sudo make setup_and_run && sleep 5

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -72,16 +72,20 @@ jobs:
           for attempt in {1..30}; do sleep 2; if curl -s http://localhost:5001/ > /dev/null; then break; fi; done
           sleep 15
 
-          # curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8000' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "200"
-          # if [ $? -eq 0 ]; then
-          #   echo "Successfully tested connection between FP->L8->FP->RP->Backend"
-          # else
-          #   echo "Failed to test connection between RP->L8"
-          # fi
-
-          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8001' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "500"
+          # Test that the backend (with port 8000) is registered with layer8
+          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8000' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "200"
           if [ $? -eq 0 ]; then
-            echo "Successfully tested that backend with port 8001 does not exist"
+            echo "Successfully tested connection between FP->L8->FP->RP->Backend"
           else
-            echo "Failed to test that backend with port 8001 does not exist"
+            echo "Failed to test connection between RP->L8"
+            exit 1
+          fi
+
+          # Test that the backend (with port 8001) is not registered with layer8
+          curl --fail-with-body --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8001' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "500"
+          if [ $? -eq 0 ]; then
+            echo "Successfully tested that backend 8001 is not registered with layer8"
+          else
+            echo "Failed to test that backend 8001 is not registered with layer8"
+            exit 1
           fi

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -19,45 +19,45 @@ jobs:
           # sudo usermod -a -G docker $USER
           # newgrp docker
 
-      # - name: Build Forward Proxy
-      #   run: |
-      #     cd forward-proxy && cargo update && cargo build
+      - name: Build Forward Proxy
+        run: |
+          cd forward-proxy && cargo update && cargo build
 
-      # - name: Build Reverse Proxy
-      #   run: |
-      #     cd reverse-proxy && cargo update && cargo build
+      - name: Build Reverse Proxy
+        run: |
+          cd reverse-proxy && cargo update && cargo build
 
       - name: Run services and test
         run: |
-          # # Install dependencies
-          # npm i -g concurrently
+          # Install dependencies
+          npm i -g concurrently
 
-          # # Start services in background
-          # concurrently "cd forward-proxy && cargo run" "cd reverse-proxy && cargo run" "cd backend && npm i && node index.js" &
+          # Start services in background
+          # Set .env file in the forward-proxy directory with JWT_SECRET_KEY=secret variable
+          cd forward-proxy && touch .env && echo "JWT_SECRET_KEY=ThisIsASecret" > .env
+          concurrently "cd forward-proxy && cargo run" "cd reverse-proxy && cargo run" "cd backend && npm i && node index.js" &
 
-          # # Wait for services to be fully ready with proper health checks
-          # echo "Waiting for services to start..."
+          # Wait for services to be fully ready with proper health checks
+          echo "Waiting for services to start..."
 
-          # # Backend services
-          # curl --retry 20 --retry-delay 2 --retry-connrefused http://localhost:3000/health -s -o /dev/null
-          # curl --retry 20 --retry-delay 2 --retry-connrefused http://localhost:6191/health -s -o /dev/null
-          # curl --retry 20 --retry-delay 2 --retry-connrefused http://localhost:6193/health -s -o /dev/null
+          # Backend services
+          curl --retry 20 --retry-delay 2 --retry-connrefused http://localhost:3000/health -s -o /dev/null
+          curl --retry 20 --retry-delay 2 --retry-connrefused http://localhost:6191/health -s -o /dev/null
+          curl --retry 20 --retry-delay 2 --retry-connrefused http://localhost:6193/health -s -o /dev/null
 
-          # # Test API connectivity
-          # echo "Testing API connectivity..."
-          # API_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
-          #   --location 'http://localhost:6191/test-endpoint' \
-          #   --header 'Content-Type: application/json' \
-          #   --data '{"data": "Test Message"}')
+          # Test API connectivity
+          echo "Testing API connectivity..."
+          API_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+            --location 'http://localhost:6191/test-endpoint' \
+            --header 'Content-Type: application/json' \
+            --data '{"data": "Test Message"}')
 
-          # if [ "$API_RESPONSE" -ne 200 ]; then
-          #   echo "API test failed with status $API_RESPONSE"
-          #   exit 1
-          # fi
+          if [ "$API_RESPONSE" -ne 200 ]; then
+            echo "API test failed with status $API_RESPONSE"
+            exit 1
+          fi
 
-          # echo "Successfully tested connection between FP->RP->Backend"
-
-          # curl --retry 20 --retry-delay 2 --retry-connrefused http://localhost:5001/health -s -o /dev/null
+          echo "Successfully tested connection between FP->RP->Backend"
 
           # docker --version
           # sudo sed -i 's|secure_path="\(.*\)"|secure_path="\1:/usr/local/go/bin"|' /etc/sudoers
@@ -78,4 +78,6 @@ jobs:
           # sudo make setup_and_run &
           make setup_and_run &
           for attempt in {1..30}; do sleep 2; if curl -s http://localhost:5001/ > /dev/null; then break; fi; done
-          # curl --location 'http://localhost:5001' -o /dev/null -w "%{http_code}\n" -s
+          sleep 15
+          curl --location 'http://localhost:5001' -o /dev/null -w "Status: %{http_code}"
+          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8000' --header 'Content-Type: application/json' -o /dev/null -w "Status: %{http_code}"

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -49,33 +49,43 @@ jobs:
             --location 'http://localhost:6191/test-endpoint' \
             --header 'Content-Type: application/json' \
             --data '{"data": "Test Message"}')
-
           if [ "$API_RESPONSE" -ne 200 ]; then
             echo "API test failed with status $API_RESPONSE"
             exit 1
           fi
-
           echo "Successfully tested connection between FP->RP->Backend"
 
-          # docker --version
-          # sudo sed -i 's|secure_path="\(.*\)"|secure_path="\1:/usr/local/go/bin"|' /etc/sudoers
-          # sudo go version
-
+          # Clone layer8 Repo
           cd /home/runner
           mkdir app-test
           cd app-test
           git clone https://github.com/globe-and-citizen/layer8.git
+
+          # Setup layer8
           cd layer8
-          # sudo make go_mod_tidy
           make go_mod_tidy
-          # cd /home/runner/app-test/layer8/infra/local && cat telegraf.conf
-          # cd /home/runner/app-test/layer8
-          # sudo make setup_and_run && sleep 5
           sed -i "s/TEST_CLIENT_BACKEND_URL=localhost:8000/TEST_CLIENT_BACKEND_URL=localhost:6001/g" server/.env.dev
           sed -i "s/TEST_CLIENT_BACKEND_URI=http:\/\/localhost:8000/TEST_CLIENT_BACKEND_URI=http:\/\/localhost:6001/g" server/.env.dev
-          # sudo make setup_and_run &
           make setup_and_run &
+
+          # Wait for service to be fully ready with proper health checks
           for attempt in {1..30}; do sleep 2; if curl -s http://localhost:5001/ > /dev/null; then break; fi; done
           sleep 15
-          curl --location 'http://localhost:5001' -o /dev/null -w "Status: %{http_code}"
-          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8000' --header 'Content-Type: application/json' -o /dev/null -w "Status: %{http_code}"
+
+          # Test that the backend (with port 8000) is registered with layer8
+          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8000' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "200"
+          if [ $? -eq 0 ]; then
+            echo "Successfully tested connection between FP->L8->FP->RP->Backend"
+          else
+            echo "Failed to test connection between RP->L8"
+            exit 1
+          fi
+
+          # Test that the backend (with port 8001) is not registered with layer8
+          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8001' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "500"
+          if [ $? -eq 0 ]; then
+            echo "Successfully tested that backend with port 8001 does not exist"
+          else
+            echo "Failed to test that backend with port 8001 does not exist"
+            exit 1
+          fi

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -84,10 +84,10 @@ jobs:
           fi
 
           # Test that the backend (with port 8001) is not registered with layer8
-          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8001' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "500" || true
-          if [ $? -eq 0 ]; then
-            echo "Successfully tested that backend 8001 is not registered with layer8"
-          else
-            echo "Failed to test that backend 8001 is not registered with layer8"
-            exit 1
-          fi
+          # curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8001' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "500" || true
+          # if [ $? -eq 0 ]; then
+          #   echo "Successfully tested that backend 8001 is not registered with layer8"
+          # else
+          #   echo "Failed to test that backend 8001 is not registered with layer8"
+          #   exit 1
+          # fi

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -80,12 +80,3 @@ jobs:
             echo "Failed to test connection between RP->L8"
             exit 1
           fi
-
-          # Test that the backend (with port 8001) is not registered with layer8
-          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8001' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "500" || true
-          if [ $? -eq 0 ]; then
-            echo "Successfully tested that backend 8001 is not registered with layer8"
-          else
-            echo "Failed to test that backend 8001 is not registered with layer8"
-            exit 1
-          fi

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -63,6 +63,8 @@ jobs:
 
           # Setup layer8
           cd layer8
+          # TODO:Temporary usage of sp-pub-key branch, to use main onece merged
+          git switch hmk/sp-pub-key
           make go_mod_tidy
           sed -i "s/TEST_CLIENT_BACKEND_URL=localhost:8000/TEST_CLIENT_BACKEND_URL=localhost:6001/g" server/.env.dev
           sed -i "s/TEST_CLIENT_BACKEND_URI=http:\/\/localhost:8000/TEST_CLIENT_BACKEND_URI=http:\/\/localhost:6001/g" server/.env.dev
@@ -78,5 +80,14 @@ jobs:
             echo "Successfully tested connection between FP->L8->FP->RP->Backend"
           else
             echo "Failed to test connection between RP->L8"
+            exit 1
+          fi
+
+          # Test that the backend (with port 8001) is not registered with layer8
+          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8001' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "500" || true
+          if [ $? -eq 0 ]; then
+            echo "Successfully tested that backend 8001 is not registered with layer8"
+          else
+            echo "Failed to test that backend 8001 is not registered with layer8"
             exit 1
           fi

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -82,10 +82,10 @@ jobs:
           fi
 
           # Test that the backend (with port 8001) is not registered with layer8
-          # curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8001' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "500" || true
-          # if [ $? -eq 0 ]; then
-          #   echo "Successfully tested that backend 8001 is not registered with layer8"
-          # else
-          #   echo "Failed to test that backend 8001 is not registered with layer8"
-          #   exit 1
-          # fi
+          curl --location 'http://localhost:6191/init-tunnel?backend_url=localhost%3A8001' --header 'Content-Type: application/json' --data '{"data": "test"}' -o /dev/null -w "Status: %{http_code}" | grep -q "500" || true
+          if [ $? -eq 0 ]; then
+            echo "Successfully tested that backend 8001 is not registered with layer8"
+          else
+            echo "Failed to test that backend 8001 is not registered with layer8"
+            exit 1
+          fi

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -59,16 +59,23 @@ jobs:
 
           # curl --retry 20 --retry-delay 2 --retry-connrefused http://localhost:5001/health -s -o /dev/null
 
-          docker --version
-          sudo sed -i 's|secure_path="\(.*\)"|secure_path="\1:/usr/local/go/bin"|' /etc/sudoers
-          sudo go version
+          # docker --version
+          # sudo sed -i 's|secure_path="\(.*\)"|secure_path="\1:/usr/local/go/bin"|' /etc/sudoers
+          # sudo go version
 
           cd /home/runner
           mkdir app-test
           cd app-test
           git clone https://github.com/globe-and-citizen/layer8.git
           cd layer8
-          sudo make go_mod_tidy
-          cd /home/runner/app-test/layer8/infra/local && cat telegraf.conf
-          cd /home/runner/app-test/layer8
-          sudo make setup_and_run && sleep 5
+          # sudo make go_mod_tidy
+          make go_mod_tidy
+          # cd /home/runner/app-test/layer8/infra/local && cat telegraf.conf
+          # cd /home/runner/app-test/layer8
+          # sudo make setup_and_run && sleep 5
+          sed -i "s/TEST_CLIENT_BACKEND_URL=localhost:8000/TEST_CLIENT_BACKEND_URL=localhost:6001/g" server/.env.dev
+          sed -i "s/TEST_CLIENT_BACKEND_URI=http:\/\/localhost:8000/TEST_CLIENT_BACKEND_URI=http:\/\/localhost:6001/g" server/.env.dev
+          # sudo make setup_and_run &
+          make setup_and_run &
+          for attempt in {1..30}; do sleep 2; if curl -s http://localhost:5001/ > /dev/null; then break; fi; done
+          curl --location 'http://localhost:5001' -o /dev/null -w "%{http_code}\n" -s

--- a/.github/workflows/e2e-fp-l8-tests.yml
+++ b/.github/workflows/e2e-fp-l8-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Build Forward Proxy
         run: |
-          cd forward-proxy && cargo update && cargo build
+          cd forward-proxy && cargo update && cargo build && touch .env && echo "JWT_SECRET_KEY=ThisIsASecret" > .env
 
       - name: Build Reverse Proxy
         run: |
@@ -33,8 +33,6 @@ jobs:
           npm i -g concurrently
 
           # Start services in background
-          # Set .env file in the forward-proxy directory with JWT_SECRET_KEY=secret variable
-          cd forward-proxy && touch .env && echo "JWT_SECRET_KEY=ThisIsASecret" > .env
           concurrently "cd forward-proxy && cargo run" "cd reverse-proxy && cargo run" "cd backend && npm i && node index.js" &
 
           # Wait for services to be fully ready with proper health checks

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ target/
 
 # All node_modules
 node_modules/
+
+.env

--- a/backend/index.js
+++ b/backend/index.js
@@ -59,6 +59,14 @@ app.post("/test-endpoint", (req, res) => {
   res.status(200).json({ data: responseData });
 });
 
+app.post("/init-tunnel", (req, res) => {
+  console.log("Received request:", req.body); // Log the entire request body to the console as well
+  if (!req.body) {
+    return res.status(400).json({ error: "Invalid request payload" });
+  }
+  res.status(200).json({ data: "OK" });
+});
+
 app.use(expressWinston.errorLogger({
   transports: [
     new winston.transports.Console(),

--- a/backend/index.js
+++ b/backend/index.js
@@ -64,7 +64,7 @@ app.post("/init-tunnel", (req, res) => {
   if (!req.body) {
     return res.status(400).json({ error: "Invalid request payload" });
   }
-  res.status(200).json({ data: "OK" });
+  res.status(200).json({ data: "Tunnel established succesfully" });
 });
 
 app.use(expressWinston.errorLogger({

--- a/forward-proxy/.env.dev
+++ b/forward-proxy/.env.dev
@@ -1,0 +1,1 @@
+JWT_SECRET_KEY=secret

--- a/forward-proxy/Cargo.lock
+++ b/forward-proxy/Cargo.lock
@@ -116,12 +116,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -1057,9 +1057,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1073,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -1164,9 +1164,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
 dependencies = [
  "jiff-static",
  "log",
@@ -1177,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1448,6 +1448,15 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2611b99ab098a31bdc8be48b4f1a285ca0ced28bd5b4f23e45efa8c63b09efa5"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "openssl"
@@ -2964,9 +2973,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -3005,18 +3014,18 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]

--- a/forward-proxy/Cargo.lock
+++ b/forward-proxy/Cargo.lock
@@ -1781,12 +1781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +1789,11 @@ dependencies = [
  "zerovec",
 ]
 
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"

--- a/forward-proxy/Cargo.lock
+++ b/forward-proxy/Cargo.lock
@@ -232,6 +232,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +509,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +538,12 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dunce"
@@ -749,8 +770,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -798,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1173,9 +1196,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07d8d955d798e7a4d6f9c58cd1f1916e790b42b092758a9ef6e16fef9f1b3fd"
+checksum = "f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806"
 dependencies = [
  "jiff-static",
  "log",
@@ -1186,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f244cfe006d98d26f859c7abd1318d85327e1882dc9cef80f62daeeb0adcf300"
+checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1213,6 +1236,21 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1395,6 +1433,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1561,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,7 +1649,7 @@ dependencies = [
  "daemonize",
  "flate2",
  "futures",
- "h2 0.4.9",
+ "h2 0.4.10",
  "http 1.3.1",
  "httparse",
  "httpdate",
@@ -1680,7 +1753,7 @@ dependencies = [
  "bytes",
  "clap",
  "futures",
- "h2 0.4.9",
+ "h2 0.4.10",
  "http 1.3.1",
  "log",
  "once_cell",
@@ -1738,6 +1811,12 @@ checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1803,7 +1882,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1820,10 +1899,13 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "dotenv",
  "env_logger",
+ "jsonwebtoken",
  "log",
  "pingora",
  "pingora-core",
+ "pingora-error",
  "pingora-http",
  "pingora-proxy",
  "reqwest",
@@ -1911,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -1953,7 +2035,7 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2073,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2092,7 +2174,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2103,9 +2185,9 @@ checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2269,6 +2351,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+ "time",
 ]
 
 [[package]]
@@ -2441,7 +2535,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2449,6 +2552,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2476,6 +2590,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",

--- a/forward-proxy/Cargo.toml
+++ b/forward-proxy/Cargo.toml
@@ -21,6 +21,9 @@ pingora-core = "0.4.0"
 pingora-proxy = "0.4.0"
 pingora-http = "0.4.0"
 pingora = "0.4.0"
+jsonwebtoken = "9.3.1"
+dotenv = "0.15.0"
+pingora-error = "0.4.0"
 
 [patch.crates-io]
 sfv = { git = "https://github.com/undef1nd/sfv.git", tag = "v0.9.4" }

--- a/forward-proxy/src/main.rs
+++ b/forward-proxy/src/main.rs
@@ -78,7 +78,9 @@ impl ProxyHttp for ForwardProxy {
                     ),
                 ));
             } else {
-                println!("Bakcend is registered");
+                // FOR LATER: Return public key here
+                // FOR NOW: return here a specific message
+                println!("Backend is registered");
             }
         }
         Ok(false)

--- a/forward-proxy/src/main.rs
+++ b/forward-proxy/src/main.rs
@@ -68,7 +68,7 @@ impl ProxyHttp for ForwardProxy {
                 .unwrap();
             println!("res status: {}", res.status().as_u16());
             // res status will either be: 500 or 401 or 200
-            if res.status().as_u16() == 500 || res.status().as_u16() == 401 {
+            if res.status().as_u16() != 200 {
                 // NOTE: error message not printing
                 return Err(pingora_core::Error::explain(
                     ErrorType::ConnectProxyFailure,

--- a/forward-proxy/src/main.rs
+++ b/forward-proxy/src/main.rs
@@ -1,17 +1,32 @@
 use async_trait::async_trait;
 use log::info;
 use pingora_core::prelude::*;
+use pingora_error::{ErrorType, Result};
 use pingora_proxy::{ProxyHttp, Session};
 use simplelog::{ConfigBuilder, LevelFilter, WriteLogger};
 use std::fs;
 use serde::{Deserialize, Serialize};
+use jsonwebtoken::{encode, Header, EncodingKey};
+use chrono::Utc;
+use reqwest::Client;
 
-
+const LAYER8_URL: &str = "http://127.0.0.1:5001";
 struct ForwardProxy;
+
+// Get SECRET_KEY from environment variable
+fn get_secret_key() -> String {
+    let secret_key = std::env::var("JWT_SECRET_KEY").expect("JWT_SECRET_KEY must be set");
+    secret_key
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ResponseBody {
     data: String,
+}
+
+#[derive(Serialize)]
+struct Claims {
+    exp: usize,
 }
 
 #[async_trait]
@@ -32,6 +47,43 @@ impl ProxyHttp for ForwardProxy {
         )))
     }
 
+    async fn request_filter(&self, session: &mut Session, _ctx: &mut Self::CTX) -> Result<bool>
+    where
+        Self::CTX: Send + Sync,
+    {
+        let request_url = session.req_header().uri.to_string();
+        if request_url.contains("init-tunnel") {
+            let query_params = session.req_header().uri.query();
+            let params: Vec<&str> = query_params.unwrap().split("=").collect();
+            let backend_url = params.get(1).unwrap();
+            let secret_key = get_secret_key();
+            let token = generate_standard_token(&secret_key).unwrap();
+            let client = Client::new();
+            println!("token: {}", token);
+            let res = client
+                .get(format!("{}{}?backend_url={}", LAYER8_URL, "/sp-pub-key", backend_url))
+                .header("Authorization", format!("Bearer {}", token))
+                .send()
+                .await
+                .unwrap();
+            println!("res status: {}", res.status().as_u16());
+            // res status will either be: 500 or 401 or 200
+            if res.status().as_u16() == 500 || res.status().as_u16() == 401 {
+                // NOTE: error message not printing
+                return Err(pingora_core::Error::explain(
+                    ErrorType::ConnectProxyFailure,
+                    format!(
+                        "Failed to get public key from layer8, status code: {}",
+                        res.status().as_u16()
+                    ),
+                ));
+            } else {
+                println!("Bakcend is registered");
+            }
+        }
+        Ok(false)
+    }
+
     async fn response_filter(
         &self,
         _session: &mut Session,
@@ -45,7 +97,24 @@ impl ProxyHttp for ForwardProxy {
     }
 }
 
+fn generate_standard_token(secret_key: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let now = Utc::now();
+    let claims = Claims {
+        exp: (now + chrono::Duration::days(1)).timestamp() as usize,
+    };
+
+    let token = encode(
+        &Header::new(jsonwebtoken::Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(secret_key.as_bytes()),
+    )?;
+
+    Ok(token)
+}
+
 fn main() {
+    // Load environment variables from .env file
+    dotenv::dotenv().ok();
     // Initialize logger
     let log_file = fs::File::create("log.txt").expect("Failed to create log file");
     let config = ConfigBuilder::new().set_time_to_local(true).build();

--- a/reverse-proxy/Cargo.lock
+++ b/reverse-proxy/Cargo.lock
@@ -116,12 +116,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -1051,9 +1051,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1067,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -1158,9 +1158,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
 dependencies = [
  "jiff-static",
  "log",
@@ -1171,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1402,6 +1402,15 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2611b99ab098a31bdc8be48b4f1a285ca0ced28bd5b4f23e45efa8c63b09efa5"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "openssl"
@@ -2842,9 +2851,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -2883,18 +2892,18 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]


### PR DESCRIPTION
This PR implements: https://github.com/globe-and-citizen/layer8-backbone/issues/4

Now when there will be an `/init-tunnel` request, the FP will do a request to layer8 `/sp-pub-key` endpoint to check if backend is registered with the layer8 or not, if yes, then it will return a pub-key (for now only returning a simple `OK` message), and if backend does not exist, the request will not continue and show error.

End-to-end tests implementation is also done to test both these cases, backend exists or not exists.